### PR TITLE
Switch to new profile URL format

### DIFF
--- a/chrome/plugin.js
+++ b/chrome/plugin.js
@@ -40,7 +40,7 @@ async function start() {
 	for (const [index, friend] of mutuals.entries()) {
 		const reference = document.createElement(`a`)
 
-		reference.setAttribute(`href`, `http://www.roblox.com/User.aspx?UserName=${friend.name}`)
+		reference.setAttribute(`href`, `https://roblox.com/users/${friend.id}/profile`)
 		reference.setAttribute(`title`, friend.displayName)
 		reference.setAttribute(`class`, `text-link`)
 		reference.innerText = friend.name

--- a/firefox/plugin.js
+++ b/firefox/plugin.js
@@ -40,7 +40,7 @@ async function start() {
 	for (const [index, friend] of mutuals.entries()) {
 		const reference = document.createElement(`a`)
 
-		reference.setAttribute(`href`, `http://www.roblox.com/User.aspx?UserName=${friend.name}`)
+		reference.setAttribute(`href`, `https://roblox.com/users/${friend.id}/profile`)
 		reference.setAttribute(`title`, friend.displayName)
 		reference.setAttribute(`class`, `text-link`)
 		reference.innerText = friend.name

--- a/tampermonkey/index.js
+++ b/tampermonkey/index.js
@@ -51,7 +51,7 @@ async function start() {
 	for (const [index, friend] of mutuals.entries()) {
 		const reference = document.createElement(`a`)
 
-		reference.setAttribute(`href`, `http://www.roblox.com/User.aspx?UserName=${friend.name}`)
+		reference.setAttribute(`href`, `https://roblox.com/users/${friend.id}/profile`)
 		reference.setAttribute(`title`, friend.displayName)
 		reference.setAttribute(`class`, `text-link`)
 		reference.innerText = friend.name


### PR DESCRIPTION
This is a simple change that switches the URL format from

```
http://www.roblox.com/User.aspx?UserName=%USERNAME%
```

to:

```
https://roblox.com/users/%USERID%/profile
```

The former version makes an unnecessary HTTP request since it redirects to the latter anyways.

Fully tested on Firefox and Tampermonkey, but it should probably work on Chrome since the file is the exact same.